### PR TITLE
Networkerror

### DIFF
--- a/arxivdaleascii
+++ b/arxivdaleascii
@@ -14,13 +14,20 @@ cat $SITES | while read line; do
   pad=`printf "%05d" $index`
   mkdir $DATE_$pad
   cd $DATE_$pad
-  /usr/bin/xvfb-run -a -s "-screen 0 1280x1024x24" /usr/bin/wkhtmltopdf --use-xserver --dpi 200 --page-size Letter --custom-header 'User-Agent' 'User-Agent Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; de-de) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4' "$line" $pad-$DATE.pdf
-  /usr/bin/xvfb-run -a -s "-screen 0 1280x1024x24" /usr/local/bin/wkhtmltoimage --use-xserver --custom-header 'User-Agent' 'User-Agent Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; de-de) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4' "$line" tmp.png
-  /usr/bin/pngcrush tmp.png $pad-$DATE.png
-  rm tmp.png
-  /usr/local/bin/wget --adjust-extension --page-requisites --convert-links --no-parent --random-wait --warc-file=$pad-$DATE "$line"
-  cd $HOME/FDA_$DATE
-  zip -r $DATE_$pad.zip $DATE_$pad
-  rm -rf $DATE_$pad
-  echo "$(date) - $line archived" >> /var/log/daleascii.log
+  WGET_ERR=`/usr/local/bin/wget --adjust-extension --page-requisites --convert-links --no-parent --random-wait --warc-file=$pad-$DATE "$line" 2>&1`
+  WGET_RESULT=$?
+  if [ $WGET_RESULT -eq 0 ] 
+  then
+    /usr/bin/xvfb-run -a -s "-screen 0 1280x1024x24" /usr/bin/wkhtmltopdf --use-xserver --dpi 200 --page-size Letter --custom-header 'User-Agent' 'User-Agent Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; de-de) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4' "$line" $pad-$DATE.pdf
+    /usr/bin/xvfb-run -a -s "-screen 0 1280x1024x24" /usr/local/bin/wkhtmltoimage --use-xserver --custom-header 'User-Agent' 'User-Agent Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; de-de) AppleWebKit/533.19.4 (KHTML, like Gecko) Version/5.0.3 Safari/533.19.4' "$line" tmp.png
+    /usr/bin/pngcrush tmp.png $pad-$DATE.png
+    rm tmp.png
+    cd $HOME/FDA_$DATE
+    zip -r $DATE_$pad.zip $DATE_$pad
+    rm -rf $DATE_$pad
+    echo "$(date) - $line archived" >> /var/log/daleascii.log
+  else
+    echo "$(date) - $line wget error $WGET_RESULT" >> /var/log/daleascii.log
+    echo $WGET_ERR >> /var/log/daleascii.log
+  fi
 done

--- a/arxivdaleascii
+++ b/arxivdaleascii
@@ -29,5 +29,6 @@ cat $SITES | while read line; do
   else
     echo "$(date) - $line wget error $WGET_RESULT" >> /var/log/daleascii.log
     echo $WGET_ERR >> /var/log/daleascii.log
+    # should do email notification here, once all the false drops are shaken out
   fi
 done


### PR DESCRIPTION
I've restructured the script to do the wget first and detect any fetch errors; if there is one it skips the other fetches and logs the error. I've only tested it on the first item in the sites list, which generates an error because of the files produces a filename that wget thinks is too long; so there's work to do to prevent that kind of error from derailing the process. Once that's done, though, I think it would be worth adding email notification of errors, to detect when legal action by EMP causes a posting to disappear. 
